### PR TITLE
Fix typo in README.md

### DIFF
--- a/csf/README.md
+++ b/csf/README.md
@@ -21,5 +21,5 @@ This script is designed to facilitate automatic allowlisting of QUIC.cloud IPs i
 Edit cronjob with the `crontab -e` command, and insert a rule similar to the following. This example will run every day at 00:00:
 
     ```
-    0 0 * * * /opt/csf-auto-update.sh
+    0 0 * * * /opt/csf-auto-update.sh -u
     ```


### PR DESCRIPTION
It was without the -u switch that way cron wouldn't auto-update the IP addresses (added -u switch to csf-auto-update.sh)